### PR TITLE
chore(deps-dev): bump typescript from 4.9.5 to 6.0.3 in /memex-vscode

### DIFF
--- a/memex-vscode/package-lock.json
+++ b/memex-vscode/package-lock.json
@@ -11,7 +11,7 @@
         "@types/node": "^25.9.1",
         "@types/vscode": "^1.75.0",
         "esbuild": "^0.28.0",
-        "typescript": "^4.9.4"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "vscode": "^1.75.0"
@@ -519,9 +519,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -529,7 +529,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/memex-vscode/package.json
+++ b/memex-vscode/package.json
@@ -84,7 +84,7 @@
   "devDependencies": {
     "@types/vscode": "^1.75.0",
     "@types/node": "^25.9.1",
-    "typescript": "^4.9.4",
+    "typescript": "^6.0.3",
     "esbuild": "^0.28.0"
   }
 }


### PR DESCRIPTION
Lands Dependabot **#6** (TypeScript 4.9.5 → 6.0.3), rebased onto master.

#6 conflicted because **#5** (@types/node 25) and **#8** (esbuild 0.28) merged first and rewrote `memex-vscode/package-lock.json`. This branch regenerates the lockfile on current master with all three at target versions.

**Verification**
- `node esbuild.js` → `Build complete.` (the real build + `vscode:prepublish` path).
- Dev-only; `tsc` is not in the build or CI, so the TS 6 `node10` moduleResolution deprecation blocks nothing (pre-existing, unrelated).

Closes #6
