### PR TITLE
v0.6.0 (Signal): finish write-discipline gaps + release plumbing

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -175,3 +175,53 @@ Per-module estimates from the test surface:
 ## Inspiration
 
 Vannevar Bush's 1945 essay "As We May Think" described the memex as a device that stores all of a person's knowledge, cross-referenced and associative. v0.3.0 brings memex closer to that vision — agents now reinforce, validate, supersede, and explain decisions as a normal part of their work, and the graph remembers it all.
+
+---
+
+# memex Audit Report — v0.6.0 (Signal)
+
+> Verify-first audit conducted 2026-06-29. Unlike the v0.3.0 pre-release sweep, this was
+> a **gap audit**: the bulk of the Signal write-discipline model had already landed
+> incrementally (Phase 8/9), so the audit ran the test suites end-to-end first and scoped
+> v0.6.0 to what was genuinely broken or missing. Confidence-state, corroboration,
+> contradiction handling, `memex review` (CLI), and validation-health stats were verified
+> present and passing rather than re-implemented.
+
+## What was verified (not rebuilt)
+
+| Signal component | Location | Verdict |
+|------------------|----------|---------|
+| Three-regime confidence (floor 0.7 / cap 0.5) | `graph/confidence.py` | Present, computed at query time |
+| Corroboration detection (two-pass, embedding sim) | `watcher/handlers.py` | **3/3 integration tests pass on live Neo4j** |
+| `corroborates`/`supersedes` + 0.85 dedup | `mcp_server/tools_write.py` | Present, passing |
+| `memex review` CLI | `cli_review.py` | Present, passing |
+| `memex stats` validation health | `graph/stats.py` | Present, passing |
+| `get_recent_decisions(corroborated_only=)` | `mcp_server/queries.py` | Present, passing |
+| Unvalidated-count banner in briefing | `mcp_server/formatter.py` | Present, passing |
+
+## Findings & fixes
+
+| ID | Severity | Finding | Resolution |
+|----|----------|---------|------------|
+| V1 | **High** | Agent `record_decision` never set `base_confidence`; `current_confidence()` fell back to `coalesce(..., 1.0)` — every agent write treated as fully trusted, defeating Signal's premise. | Explicit config-driven `base_confidence` + `validated=False` SET on write. |
+| V2 | Medium | `harnesses.*.initial_decision_confidence` config was dead — read by nothing. | `Config.initial_confidence_for()` resolver; both write paths route through it. |
+| V3 | Medium | Pillar D/D3 OTel `decision.confidence` attribute + `validated_ratio` gauge unimplemented. | Added to `graph/otel.py`; emitted from `tools_read.py`. |
+| V4 | Low | `test_briefing_includes_all_sections_when_budget_allows` was a temporal-drift bomb; master CI red. | Frozen confidence clock (autouse fixture). |
+
+All four carry regression tests. No critical findings.
+
+## Test posture (v0.6.0)
+
+- 403 test functions across 54 files (+6: 2 write-discipline, 4 OTel).
+- Offline suite (CI mirror): **377 passed**, 1 skipped, 3 deselected.
+- Corroboration integration suite green against Neo4j 5.26 Community.
+
+## Deferred (not in v0.6.0)
+
+1. **VS Code `memex.openReview`** — CLI review satisfies Pillar C; Webview is additive.
+2. **Per-client harness attribution** — needs `clientInfo` capture from the MCP
+   `initialize` handshake (the multi-agent attribution item open since v0.3.0). Until
+   then both write paths resolve the `default` harness.
+3. **Pre-condition feedback window** — the plan's mandated triage of post-article issues
+   (and a possible v0.5.2 patch) was not part of this engineering pass and remains a gate
+   before the release is tagged and published.

--- a/docs/internals/WALKTHROUGH_v0.6.0.md
+++ b/docs/internals/WALKTHROUGH_v0.6.0.md
@@ -1,0 +1,110 @@
+# memex v0.6.0 — Internal Walkthrough
+
+**Theme: Signal** — separating what the graph *knows* from what it is *guessing*, at the data layer.
+
+This release closes the remaining gaps in the Signal write-discipline model. Most of
+Signal had already landed incrementally (internally tagged "Phase 8/9"): the
+three-regime confidence model (`confidence.py`), corroboration detection
+(`watcher/handlers.py`), `record_decision` `corroborates`/`supersedes` + 0.85
+duplicate detection (`tools_write.py`), the `memex review` CLI (`cli_review.py`),
+`memex stats` validation health (`graph/stats.py`), `get_recent_decisions(corroborated_only=)`,
+and the unvalidated-count banner in briefings. v0.6.0 was scoped by a **verify-first
+audit** that ran the offline suite (mirroring CI) plus the corroboration integration
+suite against a live Neo4j, then fixed only what was genuinely broken or missing.
+
+---
+
+## Pillar 0: Verify-first audit (what the audit found)
+
+- Offline suite (CI mirror): **370 passed, 1 failed** before this work.
+- Corroboration integration suite, live Neo4j: **3/3 passed** — the core Signal
+  mechanism verified end-to-end.
+- The one offline failure was a **temporal-drift test bomb**, not a code regression,
+  and it had already turned master CI red.
+
+---
+
+## Pillar 1: Temporal-drift test fix (`tests/test_context_briefing.py`)
+
+`test_briefing_includes_all_sections_when_budget_allows` hardcoded fixture dates
+(2026-06-08/09) but scored decisions against the real wall-clock via
+`current_confidence()`. `get_context_briefing` drops decisions scoring `<= 0.5`, so
+once ~21 days of real time elapsed, the unvalidated fixture decision decayed below the
+cutoff and the assertion failed.
+
+**Fix:** an autouse fixture freezes `memex.graph.confidence._utc_now` to 2026-06-10, so
+the intended scenario (validated 1-day-old, unvalidated 2-day-old, both above the
+cutoff) is deterministic. Mirrors the `frozen_now` pattern from `test_confidence.py`
+(commit 3292927). Production logic was already correct.
+
+---
+
+## Pillar 2: Per-harness initial confidence wiring (Signal Pillar A)
+
+The `harnesses.*.initial_decision_confidence` config (defined in `config.py` and
+`config.yaml.example`) was **dead — read by nothing**. Worse, the agent
+`record_decision` path never set `base_confidence` at all, so `current_confidence()`
+fell back to `coalesce(..., 1.0)` — silently treating **every** agent-written Decision
+as a fully-trusted fact. That is the exact over-trust Signal exists to prevent; only
+the watcher synthesis path set an explicit 0.6.
+
+- `config.py`: `Config.harness_config()` / `Config.initial_confidence_for()` — a single
+  source of truth that resolves initial confidence by harness, falls back to the
+  `default` entry, and never yields an implicit 1.0.
+- `mcp_server/tools_write.py`: `record_decision` now explicitly SETs `base_confidence`
+  (config-driven), `validated=False`, `source='agent'`, and `last_reinforced_at` on the
+  new node.
+- `synthesizer/commit.py`: routes `base_confidence` through the resolver instead of
+  hardcoding 0.6 (default remains 0.6 — behaviour preserved, now tunable per repo).
+
+**Deferred:** harness *identity* is not yet threaded from the MCP `initialize`
+handshake, so both paths resolve the `default` harness. Per-client differentiation
+(claude-code 0.7 vs codex 0.6) lands when `clientInfo` capture is added — the same
+multi-agent attribution item deferred since the v0.3.0 audit.
+
+---
+
+## Pillar 3: Confidence + validation health in OpenTelemetry (Signal Pillar D / D3)
+
+The only clearly-missing Signal feature. Confidence and validation health were invisible
+in the observability pipeline that already tracks token savings.
+
+- `graph/otel.py`: `set_decision_confidence()` annotates the active span with
+  `memex.decision.confidence`; `record_validated_ratio()` drives a
+  `memex.decision.validated_ratio` gauge. Both no-op cleanly without the OTel SDK.
+- `mcp_server/tools_read.py`: `get_recent_decisions` emits the mean computed confidence
+  of returned decisions; `get_context_briefing` emits both confidence and the
+  validated/corroborated ratio. Best-effort — observability never breaks a read tool.
+
+Confidence and savings are now two axes of the same span/metrics view.
+
+---
+
+## Pillar 4: Release plumbing
+
+- Versions bumped to `0.6.0`: `pyproject.toml`, `npm/package.json`, and `server.json`
+  (MCP Registry manifest — server + both package entries, previously stale at 0.4.0).
+- `AUDIT.md` gains a v0.6.0 section.
+- The VS Code extension (`memex-vscode`) is **unchanged** at 0.4.0 — the
+  `memex.openReview` Webview command was deferred. `memex review` in the terminal
+  already satisfies Pillar C's acceptance criterion; the VS Code surface is additive.
+
+---
+
+## Test posture
+
+- 403 test functions across 54 files (+6 this release: 2 write-discipline, 4 OTel).
+- Offline suite (CI mirror): **377 passed**, 1 skipped, 3 deselected.
+- Corroboration integration suite verified green against live Neo4j 5.26 Community.
+
+---
+
+## What v0.6.0 deliberately does not include
+
+- VS Code `memex.openReview` Webview command (deferred — CLI review ships).
+- Per-client harness attribution via MCP `clientInfo` (needs `initialize` plumbing).
+- The plan's **pre-condition feedback window** (triage post-article issues, possibly a
+  v0.5.2 patch) was *not* performed as part of this engineering pass and remains a gate
+  before tagging/publishing the release.
+</content>
+</invoke>

--- a/memex/config.py
+++ b/memex/config.py
@@ -84,6 +84,28 @@ class Config(BaseModel):
     # Phase 7 — composite-reranker / RRF / conflict-detection knobs.
     retrieval: RetrievalConfig = Field(default_factory=RetrievalConfig)
 
+    def harness_config(self, harness: Optional[str]) -> HarnessConfig:
+        """Resolve the HarnessConfig for ``harness``, falling back to the
+        ``default`` entry and finally to the HarnessConfig defaults.
+
+        ``harness`` is the writing client's identity (e.g. ``claude-code``,
+        ``gemini-cli``, ``codex``) or ``None``/``"watcher"`` for the commit
+        synthesiser. Unknown harnesses resolve to ``default`` so the config
+        stays forward-compatible with clients we haven't named yet.
+        """
+        if harness and harness in self.harnesses:
+            return self.harnesses[harness]
+        if "default" in self.harnesses:
+            return self.harnesses["default"]
+        return HarnessConfig()
+
+    def initial_confidence_for(self, harness: Optional[str]) -> float:
+        """Initial ``base_confidence`` a freshly-written Decision should carry,
+        keyed by the writing harness (Signal Pillar A). This is the single
+        source of truth — agent writes and commit synthesis both route through
+        here instead of hardcoding 0.6."""
+        return self.harness_config(harness).initial_decision_confidence
+
 def load_config(repo_root: Optional[str] = None) -> Config:
     """
     Loads configuration from environment variables and optionally config.yaml.

--- a/memex/graph/otel.py
+++ b/memex/graph/otel.py
@@ -62,6 +62,57 @@ def tool_span(
         yield span
 
 
+def set_decision_confidence(confidence: float) -> None:
+    """Annotate the active span with ``memex.decision.confidence`` (Signal D3).
+
+    Called by Decision-returning tools so confidence becomes visible in the same
+    trace that already carries token-saving attributes — confidence and savings
+    as two axes of one span. No-op when the SDK isn't installed or no span is
+    active. ``confidence`` is expected in [0.0, 1.0].
+    """
+    _init_otel()
+    if _tracer is None:
+        return
+    try:
+        from opentelemetry import trace
+        span = trace.get_current_span()
+        # get_current_span never returns None, but an unrecording default span
+        # ignores set_attribute — which is exactly the no-op we want.
+        if span is not None:
+            span.set_attribute("memex.decision.confidence", float(confidence))
+    except Exception:
+        logger.debug("failed to set memex.decision.confidence", exc_info=True)
+
+
+def record_validated_ratio(ratio: float) -> None:
+    """Update the ``memex.decision.validated_ratio`` gauge (Signal D3).
+
+    The fraction of recently-surfaced decisions that are validated or
+    corroborated, emitted on each get_context_briefing call so Signal's effect
+    rides the same metrics pipeline as token savings. No-op without the SDK.
+    ``ratio`` is expected in [0.0, 1.0].
+    """
+    _init_otel()
+    if _meter is None:
+        return
+    if not hasattr(record_validated_ratio, "_gauge"):
+        try:
+            record_validated_ratio._gauge = _meter.create_gauge(
+                "memex.decision.validated_ratio",
+                description="Fraction of surfaced decisions that are validated or corroborated",
+                unit="1",
+            )
+        except Exception:
+            logger.debug("failed to create validated_ratio gauge", exc_info=True)
+            record_validated_ratio._gauge = None
+    gauge = record_validated_ratio._gauge
+    if gauge is not None:
+        try:
+            gauge.set(float(ratio))
+        except Exception:
+            logger.debug("failed to set validated_ratio gauge", exc_info=True)
+
+
 def record_token_metrics(
     tool_name: str,
     tokens_returned: int,

--- a/memex/mcp_server/queries.py
+++ b/memex/mcp_server/queries.py
@@ -87,6 +87,7 @@ async def get_recent_decisions_raw(since_days: int, module: Optional[str], limit
       d.last_reinforced_at as last_reinforced_at,
       d.created_at as created_at,
       d.validated as validated,
+      d.corroborated as corroborated,
       coalesce(d.uuid, elementId(d)) as id
     ORDER BY d.created_at DESC
     LIMIT $limit

--- a/memex/mcp_server/tools_read.py
+++ b/memex/mcp_server/tools_read.py
@@ -28,6 +28,37 @@ from memex.mcp_server.formatter import (
 
 logger = logging.getLogger(__name__)
 
+
+def _emit_decision_confidence(decisions: list) -> None:
+    """Best-effort: annotate the active OTel span with the mean computed
+    confidence of the decisions being returned (Signal D3). Never raises —
+    observability must not break a read tool."""
+    try:
+        if not decisions:
+            return
+        from memex.graph.confidence import current_confidence
+        from memex.graph.otel import set_decision_confidence
+        confs = [current_confidence(d) for d in decisions]
+        if confs:
+            set_decision_confidence(sum(confs) / len(confs))
+    except Exception:
+        logger.debug("failed to emit memex.decision.confidence", exc_info=True)
+
+
+def _emit_validated_ratio(decisions: list) -> None:
+    """Best-effort: update the validated_ratio gauge with the fraction of
+    decisions that are validated or corroborated (Signal D3). Never raises."""
+    try:
+        from memex.graph.otel import record_validated_ratio
+        if not decisions:
+            record_validated_ratio(0.0)
+            return
+        ok = sum(1 for d in decisions if (d.get("validated") or d.get("corroborated")))
+        record_validated_ratio(ok / len(decisions))
+    except Exception:
+        logger.debug("failed to emit memex.decision.validated_ratio", exc_info=True)
+
+
 async def get_project_context(scope: Optional[str] = None, repo: Optional[str] = None) -> str:
     """
     Returns a structured markdown briefing of the project.
@@ -156,6 +187,7 @@ async def get_recent_decisions(days: int = 30, module: Optional[str] = None, rep
             module=module,
             total_count=len(decisions)
         )
+        _emit_decision_confidence(decisions)
         try:
             from memex.graph.telemetry import record_tool_call
             await record_tool_call("get_recent_decisions", len(result) // 4, repo)
@@ -347,6 +379,10 @@ async def get_context_briefing(
             scored = [(d, current_confidence(d)) for d in decisions]
             scored.sort(key=lambda x: x[1], reverse=True)
             high_conf = [d for d, c in scored if c > 0.5]
+            # Signal D3 — surface confidence + validation health on this span /
+            # metrics pipeline alongside the token-saving attributes.
+            _emit_decision_confidence(decisions)
+            _emit_validated_ratio(decisions)
             if high_conf:
                 lines = []
                 for d in high_conf:

--- a/memex/mcp_server/tools_write.py
+++ b/memex/mcp_server/tools_write.py
@@ -390,9 +390,37 @@ async def record_decision(
 
             node_id = result.episode.uuid
 
-            # Explicitly set repo_path + supersedes properties
-            set_clauses = ["n.repo_path = $repo", "n.type = coalesce(n.type, 'Decision')"]
-            params = {"id": node_id, "repo": repo_path}
+            # Signal Pillar A — a freshly agent-recorded Decision must carry an
+            # explicit, config-driven base_confidence. Without this SET the node
+            # has no base_confidence and current_confidence() falls back to
+            # coalesce(..., 1.0), silently treating every agent write as a
+            # fully-trusted fact — the exact over-trust Signal exists to prevent.
+            # Harness identity isn't yet threaded from the MCP initialize
+            # handshake, so resolve the `default` harness (harness=None).
+            try:
+                initial_conf = get_config().initial_confidence_for(None)
+            except Exception:
+                initial_conf = 0.6  # never regress to the implicit 1.0 fallback
+
+            # Explicitly set repo_path + Signal confidence anchor + supersedes.
+            # validated stays False — only `memex review` (or corroboration)
+            # may raise an agent-written decision toward 1.0.
+            set_clauses = [
+                "n.repo_path = $repo",
+                "n.type = coalesce(n.type, 'Decision')",
+                "n.base_confidence = $base_confidence",
+                "n.validated = $validated",
+                "n.source = coalesce(n.source, 'agent')",
+                "n.last_reinforced_at = coalesce(n.last_reinforced_at, $now)",
+                "n.access_count = coalesce(n.access_count, 0)",
+            ]
+            params = {
+                "id": node_id,
+                "repo": repo_path,
+                "base_confidence": initial_conf,
+                "validated": False,
+                "now": now,
+            }
             if supersedes:
                 set_clauses.append("n.supersedes = $supersedes")
                 params["supersedes"] = supersedes

--- a/memex/synthesizer/commit.py
+++ b/memex/synthesizer/commit.py
@@ -75,7 +75,11 @@ async def extract_decisions(
             for d in data.get("decisions", []):
                 # v0.3.0 defaults (Phase 8 — Hallucination Mitigation):
                 #   validated=False  — watcher-synthesised, must be approved via `memex review`
-                #   base_confidence=0.6 — anchors the TempValid two-regime decay
+                #   base_confidence — config-driven (Signal Pillar A): the
+                #     synthesiser routes through the same initial-confidence
+                #     resolver as agent writes instead of hardcoding 0.6, so a
+                #     repo can tune how much it trusts unreviewed synthesis.
+                #     harness=None resolves the `default` harness (default 0.6).
                 #   source="watcher" — distinguishes from agent-recorded decisions
                 # ``last_reinforced_at`` is set to ``created_at`` by the writer so the
                 # computed_confidence helper has an anchor on freshly-synthesised nodes.
@@ -86,7 +90,7 @@ async def extract_decisions(
                     source_commit=commit_sha,
                     source="watcher",
                     validated=False,
-                    base_confidence=0.6,
+                    base_confidence=config.initial_confidence_for(None),
                 ))
                 
             return extracted_decisions

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stifler-memex-mcp",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "mcpName": "io.github.stifler7/memex",
   "description": "Developer context continuity system — temporal knowledge graph for AI coding agents via MCP. Inspired by Vannevar Bush's 1945 concept of a machine that remembers everything.",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memex-mcp"
-version = "0.5.1"
+version = "0.6.0"
 description = "Developer context continuity system — builds and maintains a temporal knowledge graph of your codebase, served to AI coding agents via MCP. Inspired by Vannevar Bush's 1945 concept of a machine that remembers everything."
 readme = "README.md"
 license = { text = "MIT" }

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.stifler7/memex",
   "description": "Temporal knowledge graph of your codebase (Graphiti + Neo4j), served to AI agents via MCP.",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "repository": {
     "url": "https://github.com/STiFLeR7/memex",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "stifler-memex-mcp",
-      "version": "0.4.0",
+      "version": "0.6.0",
       "transport": {
         "type": "stdio"
       },
@@ -58,7 +58,7 @@
     {
       "registryType": "pypi",
       "identifier": "memex-mcp",
-      "version": "0.4.0",
+      "version": "0.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/tests/test_context_briefing.py
+++ b/tests/test_context_briefing.py
@@ -90,6 +90,32 @@ def mock_queries():
     return mock_clusters, mock_decisions, mock_problems, mock_stale
 
 
+def test_emit_validated_ratio_counts_validated_and_corroborated():
+    """The validated_ratio gauge must count decisions that are validated OR
+    corroborated (D3). Regression guard: get_recent_decisions_raw must surface
+    the `corroborated` field, else corroborated-only decisions are undercounted."""
+    from memex.mcp_server.tools_read import _emit_validated_ratio
+
+    decisions = [
+        {"validated": True, "corroborated": False},   # counts
+        {"validated": False, "corroborated": True},    # counts (corroborated-only)
+        {"validated": False, "corroborated": False},   # does not count
+        {"validated": False},                          # missing key -> does not count
+    ]
+    with patch("memex.graph.otel.record_validated_ratio") as mock_ratio:
+        _emit_validated_ratio(decisions)
+        mock_ratio.assert_called_once_with(0.5)  # 2 of 4
+
+
+def test_get_recent_decisions_raw_returns_corroborated_field():
+    """The raw decisions query must RETURN `corroborated` so validation-health
+    telemetry can distinguish corroborated-only decisions."""
+    import inspect
+    from memex.mcp_server import queries
+    src = inspect.getsource(queries.get_recent_decisions_raw)
+    assert "as corroborated" in src
+
+
 @pytest.mark.asyncio
 async def test_briefing_includes_all_sections_when_budget_allows(mock_queries):
     clusters, decisions, problems, stale = mock_queries

--- a/tests/test_context_briefing.py
+++ b/tests/test_context_briefing.py
@@ -5,10 +5,27 @@ and telemetry recording without requiring a live Neo4j or Gemini backend.
 """
 
 from __future__ import annotations
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 import pytest
 
 from memex.mcp_server.tools_read import get_context_briefing
+
+
+# The mock decisions below carry fixed ``created_at`` dates (2026-06-08/09).
+# ``get_context_briefing`` scores each decision via ``current_confidence`` and
+# drops anything <= 0.5, so without a frozen clock the unvalidated decision
+# decays below the cutoff once ~21 days of real wall-clock elapse — making
+# ``test_briefing_includes_all_sections_when_budget_allows`` a time bomb.
+# Freeze the confidence clock to just after the fixture dates so the intended
+# scenario (validated 1-day-old, unvalidated 2-day-old, both fresh) is stable.
+_FROZEN_NOW = datetime(2026, 6, 10, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def _frozen_confidence_clock():
+    with patch("memex.graph.confidence._utc_now", return_value=_FROZEN_NOW):
+        yield
 
 
 @pytest.fixture

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -5,17 +5,17 @@ from unittest.mock import MagicMock, patch
 @pytest.fixture(autouse=True)
 def reset_otel_state():
     import memex.graph.otel
-    memex.graph.otel._tracer = None
-    memex.graph.otel._meter = None
-    memex.graph.otel._initialized = False
-    if hasattr(memex.graph.otel.record_token_metrics, "_counters"):
-        delattr(memex.graph.otel.record_token_metrics, "_counters")
+    def _clear():
+        memex.graph.otel._tracer = None
+        memex.graph.otel._meter = None
+        memex.graph.otel._initialized = False
+        if hasattr(memex.graph.otel.record_token_metrics, "_counters"):
+            delattr(memex.graph.otel.record_token_metrics, "_counters")
+        if hasattr(memex.graph.otel.record_validated_ratio, "_gauge"):
+            delattr(memex.graph.otel.record_validated_ratio, "_gauge")
+    _clear()
     yield
-    memex.graph.otel._tracer = None
-    memex.graph.otel._meter = None
-    memex.graph.otel._initialized = False
-    if hasattr(memex.graph.otel.record_token_metrics, "_counters"):
-        delattr(memex.graph.otel.record_token_metrics, "_counters")
+    _clear()
 
 
 def test_tool_span_yields_none_without_sdk():
@@ -106,6 +106,52 @@ async def test_record_tool_call_emits_otel(mock_record_otel, mock_db_class):
         1200,  # search_context naive multiplier is 12 (100 * 12 = 1200)
         1100   # saved = 1200 - 100 = 1100
     )
+
+
+def test_set_decision_confidence_noop_without_sdk():
+    with patch.dict("sys.modules", {"opentelemetry": None}):
+        import memex.graph.otel
+        # Should run without raising when the SDK is absent.
+        memex.graph.otel.set_decision_confidence(0.73)
+
+
+def test_set_decision_confidence_sets_attribute_on_span():
+    mock_tracer = MagicMock()
+    mock_span = MagicMock()
+
+    with patch("opentelemetry.trace.get_tracer", return_value=mock_tracer), \
+         patch("opentelemetry.trace.get_current_span", return_value=mock_span):
+        import memex.graph.otel
+        memex.graph.otel.set_decision_confidence(0.73)
+
+        mock_span.set_attribute.assert_called_once_with("memex.decision.confidence", 0.73)
+
+
+def test_record_validated_ratio_noop_without_sdk():
+    with patch.dict("sys.modules", {"opentelemetry": None}):
+        import memex.graph.otel
+        memex.graph.otel.record_validated_ratio(0.5)
+
+
+def test_record_validated_ratio_creates_and_sets_gauge():
+    mock_meter = MagicMock()
+    mock_gauge = MagicMock()
+    mock_meter.create_gauge.return_value = mock_gauge
+
+    with patch("opentelemetry.metrics.get_meter", return_value=mock_meter):
+        import memex.graph.otel
+        memex.graph.otel.record_validated_ratio(0.42)
+        # second call must reuse the gauge, not recreate it
+        memex.graph.otel.record_validated_ratio(0.84)
+
+        mock_meter.create_gauge.assert_called_once_with(
+            "memex.decision.validated_ratio",
+            description="Fraction of surfaced decisions that are validated or corroborated",
+            unit="1",
+        )
+        assert mock_gauge.set.call_count == 2
+        mock_gauge.set.assert_any_call(0.42)
+        mock_gauge.set.assert_any_call(0.84)
 
 
 def test_init_otel_idempotent():

--- a/tests/test_write_discipline.py
+++ b/tests/test_write_discipline.py
@@ -232,3 +232,60 @@ async def test_get_recent_decisions_corroborated_only(mock_client):
     call_args = mock_client.driver.execute_query.call_args
     assert call_args[1]["params"]["corroborated_only"] is True
     assert "$corroborated_only = false OR d.corroborated = true OR d.validated = true" in call_args[0][0]
+
+
+# --- Signal Pillar A: per-harness initial confidence wiring -----------------
+
+def test_initial_confidence_for_resolves_by_harness():
+    """The config resolver keys initial confidence by harness, falling back to
+    the `default` entry and finally to the HarnessConfig default (0.6)."""
+    from memex.config import Config, HarnessConfig
+
+    cfg = Config(
+        neo4j_uri="x", neo4j_user="x", neo4j_password="x", gemini_api_key="x",
+        harnesses={
+            "claude-code": HarnessConfig(initial_decision_confidence=0.7),
+            "default": HarnessConfig(initial_decision_confidence=0.6),
+        },
+    )
+    assert cfg.initial_confidence_for("claude-code") == 0.7
+    assert cfg.initial_confidence_for("codex") == 0.6   # unknown harness -> default
+    assert cfg.initial_confidence_for(None) == 0.6      # watcher synthesis -> default
+
+    # No harness config at all -> HarnessConfig field default, never an
+    # implicit 1.0.
+    bare = Config(neo4j_uri="x", neo4j_user="x", neo4j_password="x", gemini_api_key="x")
+    assert bare.initial_confidence_for("anything") == 0.6
+
+
+@pytest.mark.asyncio
+async def test_record_decision_sets_configured_initial_confidence(mock_client):
+    """Agent-recorded decisions must carry the configured initial base_confidence
+    (Signal Pillar A) rather than the implicit coalesce(..., 1.0) over-trust
+    fallback that current_confidence applies when base_confidence is unset."""
+    mock_client.add_episode.return_value = MagicMock(episode=MagicMock(uuid="agent-dec-1"))
+    mock_client.driver.execute_query.return_value = MagicMock(records=[])
+
+    with patch("memex.mcp_server.tools_write.get_config") as mock_cfg:
+        cfg = MagicMock()
+        cfg.initial_confidence_for.return_value = 0.55
+        mock_cfg.return_value = cfg
+
+        res = await record_decision(
+            text="Adopt EdDSA token signing for rotation simplicity",
+            module="auth.py",
+            repo=".",
+            force=True,  # skip Layer B intent-confirmation
+        )
+
+    assert "decision recorded" in res
+    set_calls = [
+        c for c in mock_client.driver.execute_query.call_args_list
+        if "base_confidence" in c[0][0]
+    ]
+    assert set_calls, "expected a SET writing base_confidence on the new Decision node"
+    params = set_calls[0][1]["params"]
+    assert params["base_confidence"] == 0.55
+    assert params["validated"] is False
+    # The configured harness default (None -> default) must have been consulted.
+    cfg.initial_confidence_for.assert_called()


### PR DESCRIPTION
## Summary

Verify-first pass that completes the **Signal** write-discipline model. A gap audit found most of Signal had already shipped (Phase 8/9), so this scopes v0.6.0 to what was genuinely broken or missing — and fixes a latent **High**-severity over-trust bug along the way.

- **fix(test):** `test_briefing_includes_all_sections_when_budget_allows` was a temporal-drift bomb (hardcoded fixture dates vs. real wall-clock) that had turned **master CI red**. Frozen confidence clock via autouse fixture (mirrors `test_confidence.py`'s `frozen_now`). Production logic was already correct.
- **feat(signal):** wire per-harness `initial_decision_confidence` (Pillar A). The config was dead, and worse, agent `record_decision` never set `base_confidence` — so `current_confidence()` fell back to `coalesce(..., 1.0)`, silently treating every agent write as a fully-trusted fact. Now both write paths (agent + watcher synthesis) route through `Config.initial_confidence_for()` and never yield an implicit 1.0.
- **feat(signal):** emit `memex.decision.confidence` span attribute + `memex.decision.validated_ratio` gauge to OpenTelemetry (Pillar D / D3) — confidence and token-savings on the same observability axes.
- **release:** bump to `0.6.0` (pyproject, npm, `server.json` MCP-registry manifest), add the v0.6.0 AUDIT section + walkthrough.

## Verification

- Offline suite (CI mirror, no Neo4j): **377 passed**, 1 skipped, 3 deselected.
- Corroboration integration suite: **3/3 pass** against live Neo4j 5.26 Community.
- +6 new tests (2 write-discipline, 4 OTel).

## Deferred (not in this PR)

- VS Code `memex.openReview` Webview — CLI `memex review` already satisfies Pillar C.
- Per-client harness attribution — needs `clientInfo` capture from the MCP `initialize` handshake (open since v0.3.0); until then both paths resolve the `default` harness.
- **Pre-condition feedback window** — the plan's mandated triage of post-article issues (and a possible v0.5.2 patch) remains a gate before this release is **tagged/published**.

## Test Plan

- [ ] CI green on the offline matrix (`-m "not integration"` + integration-file ignores).
- [ ] Spot-check `record_decision` against a live Neo4j: new agent Decision carries `base_confidence` < 1.0 and `validated=false`.
- [ ] With an OTel exporter configured, confirm `memex.decision.confidence` on tool spans and the `validated_ratio` gauge after a `get_context_briefing` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)