### PR TITLE
ci: hands-free idempotent publish pipeline (npm OIDC + skip-existing + registry)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual trigger so the pipeline can be re-run against an already-published
+  # version — e.g. to (re)register on the MCP Registry after a manual npm/PyPI
+  # publish. The publish jobs are idempotent (skip-if-exists), so this is safe.
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -31,8 +35,8 @@ jobs:
           GEMINI_API_KEY: "dummy"
         # Excluded suites require a live Neo4j / Gemini backend that CI
         # doesn't provision. They run locally via `docker compose up`
-        # and against staging. The remaining 332+ tests cover the
-        # public surface; coverage stays above 90%.
+        # and against staging. The remaining tests cover the public
+        # surface; coverage stays above 90%.
         run: |
           uv run pytest tests/ -v \
             --ignore=tests/test_corroboration.py \
@@ -67,41 +71,63 @@ jobs:
         run: uv run twine check dist/*
 
       - name: Publish to PyPI
+        # --skip-existing makes re-runs (and manual pre-publishes) idempotent:
+        # a version already on PyPI is skipped instead of 400-ing the job.
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API }}
-        run: uv run twine upload dist/*
+        run: uv run twine upload --skip-existing dist/*
 
   publish-npm:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      # OIDC trusted publishing — no NPM token/2FA. Requires a one-time
+      # "Trusted Publisher" config on npmjs.com for `stifler-memex-mcp`
+      # (org STiFLeR7, repo memex, workflow publish.yml). See README/AUDIT.
+      id-token: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
+          # never cache in release builds
+          package-manager-cache: false
+
+      - name: Upgrade npm for OIDC trusted publishing
+        # Trusted publishing requires npm >= 11.5.1; Node 22 ships an older npm.
+        run: npm install -g npm@latest
 
       - name: Copy README and LICENSE into npm package
         run: |
           cp README.md npm/README.md
           cp LICENSE npm/LICENSE
 
-      - name: Publish to npm
+      - name: Publish to npm (OIDC, skip if already published)
         working-directory: npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_API }}
+        # No NODE_AUTH_TOKEN: authentication is via OIDC trusted publishing.
+        # Skip-if-exists keeps re-runs and manual pre-publishes idempotent.
+        run: |
+          NAME=$(jq -r .name package.json)
+          VER=$(jq -r .version package.json)
+          if npm view "$NAME@$VER" version >/dev/null 2>&1; then
+            echo "$NAME@$VER already published — skipping"
+          else
+            npm publish --access public
+          fi
 
   # Lists the server on the official MCP Registry
-  # (registry.modelcontextprotocol.io). Gated on both package jobs because
-  # the registry validates each server.json package's ownership marker
-  # (npm: package.json `mcpName`; PyPI: README `mcp-name:` comment) against
-  # the just-published artifact. Auth is GitHub OIDC — no stored secret; the
-  # workflow's OIDC identity (STiFLeR7/memex) authorizes the
-  # io.github.stifler7/* namespace.
+  # (registry.modelcontextprotocol.io). Gated on both package jobs because the
+  # registry validates each server.json package's ownership marker
+  # (npm: package.json `mcpName`; PyPI: README `mcp-name:` comment) against the
+  # live published artifact. Because the publish jobs are now idempotent, this
+  # runs cleanly whether the version was published by CI or manually
+  # beforehand. Auth is GitHub OIDC — no stored secret; the workflow's OIDC
+  # identity (STiFLeR7/memex) authorizes the io.github.stifler7/* namespace.
   publish-registry:
     needs: [publish-pypi, publish-npm]
     runs-on: ubuntu-latest
@@ -112,9 +138,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Sync server.json versions to the release tag
+      - name: Sync server.json versions to the package version
+        # Source of truth is npm/package.json so this works for both a tag
+        # push and a manual workflow_dispatch (no tag ref required).
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
+          VERSION=$(jq -r .version npm/package.json)
           jq --arg v "$VERSION" '.version = $v | (.packages[].version) = $v' \
             server.json > server.tmp && mv server.tmp server.json
           cat server.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,5 +97,27 @@ Maintainers review regularly. CI (tests on push tags / PRs) must be green.
 ## Releases
 
 Releases are tag-driven: pushing a `v*` tag runs the publish workflow
-(PyPI + npm + MCP Registry). Maintainers cut releases; contributors don't need
-to bump versions in their PRs.
+(`.github/workflows/publish.yml`), which publishes **PyPI + npm + MCP Registry**.
+Version bumps must update **both** `pyproject.toml` and `npm/package.json` (and
+they must agree); `server.json` tracks the same version. Maintainers cut
+releases; contributors don't need to bump versions in their PRs.
+
+The three publish jobs are **idempotent** — a version already on PyPI/npm is
+skipped rather than failing the run. So a maintainer can publish manually and
+still let CI complete the MCP Registry listing, and re-runs are safe.
+
+**Authentication (no npm 2FA/OTP in CI):**
+
+- **npm → OIDC Trusted Publishing.** No `NPM_API` token; the job uses
+  `id-token: write` and npm ≥ 11.5.1. **One-time setup on npmjs.com** (required
+  before the npm job can publish): package `stifler-memex-mcp` → *Settings* →
+  *Trusted Publisher* → GitHub Actions → org `STiFLeR7`, repo `memex`, workflow
+  `publish.yml`, allowed action `npm publish`.
+- **PyPI → token.** Repo secret `PYPI_API` (`__token__` / API token). Trusted
+  publishing optional; the token path is already OTP-free.
+- **MCP Registry → GitHub OIDC.** No stored secret; the workflow's OIDC identity
+  (`STiFLeR7/memex`) authorizes the `io.github.stifler7/*` namespace.
+
+To (re)register on the MCP Registry against an already-published version without
+cutting a new tag, run the workflow via **Actions → Publish → Run workflow**
+(`workflow_dispatch`).


### PR DESCRIPTION
## Root cause (systematic debugging)

Evidence: every `publish.yml` run for **v0.3.5 → v0.5.1** is red, yet npm and PyPI are both live at 0.5.1 (published **manually**).

- **`publish-npm` fails with `npm error code EOTP`** — `NPM_API` is a classic token with publish-2FA enabled; CI can't supply an OTP. (Confirmed in the v0.5.1 run logs + by the maintainer.)
- **`publish-pypi`'s red is mostly a re-run artifact** — the 2nd v0.5.1 run `400`'d because 0.5.1 was already uploaded by the 1st.
- **Consequence:** `publish-registry` has `needs: [publish-pypi, publish-npm]`, so it's **skipped on every tag** → memex has never actually landed on registry.modelcontextprotocol.io, despite the packages shipping fine.

The stale assumption that "npm is stuck at 0.3.6" was disproven — npm is at 0.5.1 via manual publishing.

## Fix — full pipeline, hands-free

- **npm → OIDC Trusted Publishing** (mirrors how `publish-pypi` already authenticates): drop `NODE_AUTH_TOKEN`/`NPM_API`, add `id-token: write`, upgrade npm to ≥ 11.5.1 on Node 22. Kills EOTP at the root.
- **Idempotency:** npm skips if the version already exists; PyPI uses `twine upload --skip-existing`. Re-runs and manual pre-publishes no longer turn the workflow red — **so `publish-registry` finally runs.**
- **`workflow_dispatch`** trigger + version sourced from `npm/package.json` (not the tag ref) → can (re)register on the MCP Registry against an already-published version without cutting a new tag.

## ⚠️ Required one-time activation (maintainer, on npmjs.com)

The npm job can't publish until Trusted Publishing is configured:
**npmjs.com → package `stifler-memex-mcp` → Settings → Trusted Publisher → GitHub Actions →** org `STiFLeR7`, repo `memex`, workflow `publish.yml`, allowed action `npm publish`. (Documented in `CONTRIBUTING.md` → Releases.)

Until then the npm job fails the same way it does today (just via OIDC instead of EOTP), so this is not a regression.

## Verification

Static only — a live run publishes packages, so it can't be exercised in CI safely:
- YAML parses; per-job `permissions`/`needs` verified; version + `server.json` jq transform simulated; confirmed OIDC-only (no token env, no `NPM_API`).
- **End-to-end test:** after the npmjs.com config above, either push a `v0.6.0` tag or run the workflow manually — expect npm + PyPI + MCP Registry all green and hands-free.

## Test Plan

- [ ] Configure npm Trusted Publisher (above).
- [ ] `workflow_dispatch` run → PyPI/npm skip 0.6.0 if already published, `publish-registry` succeeds and memex appears on the MCP Registry.
- [ ] Push `v0.6.0` tag on a clean version → all three jobs green with no manual OTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)